### PR TITLE
fix: Jpa Auditing 설정 누락 수정

### DIFF
--- a/src/main/java/com/sb10findexteam6/common/config/JpaConfig.java
+++ b/src/main/java/com/sb10findexteam6/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.sb10findexteam6.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}


### PR DESCRIPTION
## 작업 내용
- 추가 했던 BaseEntity의 createdAt의 값이 null이 되는 문제 발견 후
jpa auditing을 활성화 하는 설정이 누락된 것을 확인 후 수정

## 관련 이슈
- 

## 변경 사항
- config 패키지에 JpaConfig를 추가
- JpaConfig에 EnableJpaAuditing 작성

## 테스트
- 

## 리뷰 포인트
- 